### PR TITLE
The delete endpoint now returns JSON

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -106,7 +106,7 @@ def view_patch():
 def view_delete():
     """Returns DETLETE Data."""
 
-    return get_dict('url', 'args', 'data', 'origin', 'headers')
+    return jsonify(get_dict('url', 'args', 'data', 'origin', 'headers'))
 
 
 @app.route('/gzip')


### PR DESCRIPTION
Before:

``` bash
$ curl -X DELETE http://localhost:8000/delete
:(
```

After:

``` bash
$ curl -X DELETE http://localhost:8000/delete
{
  "url": "http://localhost:8000/delete", 
  "origin": "127.0.0.1", 
  "args": {}, 
  "data": "", 
  "headers": {
    "Host": "localhost:8000", 
    "Content-Type": "", 
    "Content-Length": "", 
    "Accept": "*/*", 
    "User-Agent": "curl/7.19.7 (universal-apple-darwin10.0) libcurl/7.19.7 OpenSSL/0.9.8r zlib/1.2.3"
  }
}
```
