### PR TITLE
Add base64-decoding endpoint for specifying arbitrary response strings

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -7,6 +7,7 @@ httpbin.core
 This module provides the core HttpBin experience.
 """
 
+import base64
 import json
 import os
 import time
@@ -240,6 +241,12 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
         return status_code(403)
     return dict(authenticated=True, user=user)
 
+
+@app.route('/base64/<value>')
+def decode_base64(value):
+    """Decodes base64url-encoded string"""
+    encoded = value.encode('utf-8')
+    return base64.urlsafe_b64decode(encoded).decode('utf-8')
 
 
 if __name__ == '__main__':

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import httpbin
+import unittest
+import base64
+
+
+def _string_to_base64(string):
+    """Encodes string to utf-8 and then base64"""
+    utf8_encoded = string.encode('utf-8')
+    return base64.urlsafe_b64encode(utf8_encoded)
+
+
+class HttpbinTestCase(unittest.TestCase):
+    """Httpbin tests"""
+
+    def setUp(self):
+        self.app = httpbin.app.test_client()
+
+    def test_base64(self):
+        greeting = u'Здравствуй, мир!'
+        b64_encoded = _string_to_base64(greeting)
+        response = self.app.get('/base64/{}'.format(b64_encoded))
+        content = response.data.decode('utf-8')
+        self.assertEquals(greeting, content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This was prompted by a bug in the iter_lines function in requests which causes any trailing text after the final newline to become truncated. I wanted to submit a patch but couldn't think of a way to write a test that followed requests's convention of using httpbin for tests.

This patch adds an endpoint that decodes a URL fragment using the 'base64url' decoding, as described in [RFC 4648, section 5](http://tools.ietf.org/html/rfc4648#section-5) into a UTF-8 string. I also added a test.
