### PR TITLE
jsonify on digest_auth()

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -215,7 +215,7 @@ def hidden_basic_auth(user='user', passwd='passwd'):
 
     if not check_basic_auth(user, passwd):
         return status_code(404)
-    return dict(authenticated=True, user=user)
+    return jsonify(authenticated=True, user=user)
 
 
 @app.route('/digest-auth/<qop>/<user>/<passwd>')
@@ -239,7 +239,7 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
         return response
     elif not check_digest_auth(user, passwd):
         return status_code(403)
-    return dict(authenticated=True, user=user)
+    return jsonify(authenticated=True, user=user)
 
 
 @app.route('/base64/<value>')


### PR DESCRIPTION
Hi,
There is any reason for digest_auth() doesn't use jsonify on its return?
Without it I always get the sad smiley from page_not_found.
