### PR TITLE
401 is a more proper status_code for failed authentication

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -269,7 +269,7 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
         response.headers['WWW-Authenticate'] = auth.to_header()
         return response
     elif not check_digest_auth(user, passwd):
-        return status_code(403)
+        return status_code(401)
     return jsonify(authenticated=True, user=user)
 
 


### PR DESCRIPTION
401 is a more proper status_code for failed authentication, in fact we're already using a 401 for failed http basic authentication requests.

10.4.2 401 Unauthorized

The request requires user authentication. The response MUST include a
WWW-Authenticate header field (section 14.47) containing a challenge applicable
to the requested resource. The client MAY repeat the request with a suitable
Authorization header field (section 14.8). If the request already included
Authorization credentials, then the 401 response indicates that authorization
has been refused for those credentials. If the 401 response contains the same
challenge as the prior response, and the user agent has already attempted
authentication at least once, then the user SHOULD be presented the entity that
was given in the response, since that entity might include relevant diagnostic
information. HTTP access authentication is explained in "HTTP Authentication:
Basic and Digest Access Authentication" [43].

10.4.4 403 Forbidden

The server understood the request, but is refusing to fulfill it. Authorization
will not help and the request SHOULD NOT be repeated. If the request method was
not HEAD and the server wishes to make public why the request has not been
fulfilled, it SHOULD describe the reason for the refusal in the entity. If the
server does not wish to make this information available to the client, the
status code 404 (Not Found) can be used instead.
