### PR TITLE
Robots Support and Simple Html response

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -14,12 +14,12 @@ import time
 
 import newrelic.agent
 
-from flask import Flask, Response, request, render_template, redirect, jsonify
+from flask import Flask, Response, request, render_template, redirect, jsonify, make_response
 from raven.contrib.flask import Sentry
 from werkzeug.datastructures import WWWAuthenticate
 
 from . import filters
-from .helpers import get_headers, status_code, get_dict, check_basic_auth, check_digest_auth, H
+from .helpers import get_headers, status_code, get_dict, check_basic_auth, check_digest_auth, H, ROBOT_TXT, ANGRY_ASCII
 from .utils import weighted_choice
 from .structures import CaseInsensitiveDict
 
@@ -49,6 +49,33 @@ def view_landing_page():
     """Generates Landing Page."""
 
     return render_template('index.html')
+
+
+@app.route('/html')
+def view_html_page():
+    """Simple Html Page"""
+
+    return render_template('moby.html')
+
+
+@app.route('/robots.txt')
+def view_robots_page():
+    """Simple Html Page"""
+
+    response = make_response()
+    response.data = ROBOT_TXT
+    response.content_type = "text/plain"
+    return response
+
+
+@app.route('/deny')
+def view_deny_page():
+    """Simple Html Page"""
+    response = make_response()
+    response.data = ANGRY_ASCII
+    response.content_type = "text/plain"
+    return response
+    # return "YOU SHOULDN'T BE HERE"
 
 
 @app.route('/ip')

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -45,7 +45,22 @@ ENV_HEADERS = (
     'X-Forwarded-Port'
 )
 
+ROBOT_TXT = """User-agent: *
+Disallow: /deny
+"""
 
+ANGRY_ASCII ="""
+          .-''''''-.
+        .' _      _ '.
+       /   O      O   \\
+      :                :
+      |                |
+      :       __       :
+       \  .-"`  `"-.  /
+        '.          .'
+          '-......-'
+      YOU SHOUDN'T BE HERE
+"""
 
 def get_files():
     """Returns files dict from request context."""

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -26,6 +26,9 @@
 <li><a href="/digest-auth/auth/user/passwd"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
 <li><a href="/stream/20"><code>/stream/:n</code></a> Streams <em>n</em>–100 lines.</li>
 <li><a href="/delay/3"><code>/delay/:n</code></a> Delays responding for <em>n</em>–10 seconds.</li>
+<li><a href="/html"><code>/html</code></a> Renders an HTML Page</li>
+<li><a href="/robots.txt"><code>/robots.txt</code></a> Returns some robots.txt rules</li>
+<li><a href="/deny"><code>/deny</code></a> Denied by robots.txt file</li>
 </ul>
 
 


### PR DESCRIPTION
Added support for:
    \* Robots.txt requests which is usefule for robots rules tests.
    \* Robots denied page (/deny)
    \* Simple html page for views / calls that expect an html.
