### PR TITLE
simulation support

### DIFF
--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -26,6 +26,8 @@
 <li><a href="/digest-auth/auth/user/passwd"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
 <li><a href="/stream/20"><code>/stream/:n</code></a> Streams <em>n</em>–100 lines.</li>
 <li><a href="/delay/3"><code>/delay/:n</code></a> Delays responding for <em>n</em>–10 seconds.</li>
+<li><a href="/simulate/"><code>/simulate/</code></a> Crude simulation
+  of http traffic. Sleeps randomly and returns 200, 500, 404 or 402 randomly.</li>
 </ul>
 
 


### PR DESCRIPTION
New endpoint to do a very simple simulation of a long http request.

The server will delay response randomly following a log normal distribution.

3% of the requests will return error status codes instead of 200.
