### PR TITLE
Support for HTTP Basic Auth + POST data

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -269,6 +269,18 @@ def basic_auth(user='user', passwd='passwd'):
     return jsonify(authenticated=True, user=user)
 
 
+@app.route('/basic-auth-post/<user>/<passwd>', methods=('POST',))
+def basic_auth_post(user='user', passwd='passwd'):
+    """Prompts the user for authorization using HTTP Basic Auth and returns
+    POST data."""
+
+    if not check_basic_auth(user, passwd):
+        return status_code(401)
+
+    return jsonify(get_dict('url', 'args', 'form', 'data', 'origin', 'headers',
+        'files', 'json'), authenticated=True, user=user)
+
+
 @app.route('/hidden-basic-auth/<user>/<passwd>')
 def hidden_basic_auth(user='user', passwd='passwd'):
     """Prompts the user for authorization using HTTP Basic Auth."""


### PR DESCRIPTION
Hi Kenneth,

This pull request is for supporting Basic Auth + POST data, e.g.:

```
curl --user "foo:bar" -d "monty=python" "http://localhost:5000/basic-auth-post/foo/bar"
```

 I'm not sure if the route I selected is semantically the sort you'd prefer--I apologize if it's not.

Cheers,

Benjamin
