### PR TITLE
Bugfix: JSON-safe encoding of raw binary data/files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Patches and Suggestions
 - Lispython
 - Kyle Conroy
 - Flavio Percoco
+- Radomir Stevanovic (http://github.com/randomir)

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -25,6 +25,22 @@ class HttpbinTestCase(unittest.TestCase):
         content = response.data.decode('utf-8')
         self.assertEquals(greeting, content)
 
+    def test_post_binary(self):
+        response = self.app.post('/post',
+                                 data='\x01\x02\x03\x81\x82\x83',
+                                 content_type='application/octet-stream')
+        self.assertEquals(response.status_code, 200)
+
+    def test_post_file_text(self):
+        with open('httpbin/core.py') as f:
+            response = self.app.post('/post', data={"file": f})
+        self.assertEquals(response.status_code, 200)
+
+    def test_post_file_binary(self):
+        with open('httpbin/core.pyc') as f:
+            response = self.app.post('/post', data={"file": f})
+        self.assertEquals(response.status_code, 200)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Encoding of the received files and/or body data was failing in case of raw
binary data being POSTed/PUT/etc. (The exact trigger was actually a non-UTF-8
data stream, since Flask's `jsonify`, i.e. `simplejson.dumps` assumes UTF-8.)

Binary data in a JSON response are now encoded as "data" URLs, according to
RFC 2397. "Data" URL scheme was chosen for its simplicity and clarity. MIME
type is included. Plain text is passed thru unmodified, as before.

Also, tests demonstrating the bug/fix added to `test_httpbin.py`.
