### PR TITLE
Support for setting multiple cookies in a single request.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Patches and Suggestions
 - Kyle Conroy
 - Flavio Percoco
 - Radomir Stevanovic (http://github.com/randomir)
+- Steven Honson

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Freely hosted in [HTTP](http://httpbin.org) &
 - [`/relative-redirect/:n`](http://httpbin.org/relative-redirect/6) 302 Relative redirects *n* times.
 - [`/cookies`](http://httpbin.org/cookies) Returns cookie data.
 - [`/cookies/set/:name/:value`](http://httpbin.org/cookies/set/key/value) Sets a simple cookie.
+- [`/cookies/set?name=value`](http://httpbin.org/cookies/set?k1=v1&k2=v2) Sets one or more simple cookies.
 - [`/basic-auth/:user/:passwd`](http://httpbin.org/basic-auth/user/passwd) Challenges HTTPBasic Auth.
 - [`/hidden-basic-auth/:user/:passwd`](http://httpbin.org/hidden-basic-auth/user/passwd) 404'd BasicAuth.
 - [`/digest-auth/:qop/:user/:passwd`](http://httpbin.org/digest-auth/auth/user/passwd) Challenges HTTP Digest Auth.

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -259,6 +259,18 @@ def set_cookie(name, value):
     return r
 
 
+@app.route('/cookies/set')
+def set_cookies():
+    """Sets cookie(s) as provided by the query string and redirects to cookie list."""
+
+    cookies = dict(request.args.items())
+    r = app.make_response(redirect('/cookies'))
+    for key, value in cookies.items():
+        r.set_cookie(key=key, value=value)
+
+    return r
+
+
 @app.route('/basic-auth/<user>/<passwd>')
 def basic_auth(user='user', passwd='passwd'):
     """Prompts the user for authorization using HTTP Basic Auth."""

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -21,6 +21,7 @@
 <li><a href="/relative-redirect/6"><code>/relative-redirect/:n</code></a> 302 Relative redirects <em>n</em> times.</li>
 <li><a href="/cookies" data-bare-link="true"><code>/cookies</code></a> Returns cookie data.</li>
 <li><a href="/cookies/set/key/value"><code>/cookies/set/:name/:value</code></a> Sets a simple cookie.</li>
+<li><a href="/cookies/set?k1=v1&amp;k2=v2"><code>/cookies/set?name=value</code></a> Sets one or more simple cookies.</li>
 <li><a href="/basic-auth/user/passwd"><code>/basic-auth/:user/:passwd</code></a> Challenges HTTPBasic Auth.</li>
 <li><a href="/hidden-basic-auth/user/passwd"><code>/hidden-basic-auth/:user/:passwd</code></a> 404'd BasicAuth.</li>
 <li><a href="/digest-auth/auth/user/passwd"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>


### PR DESCRIPTION
As requested in #17, support for setting multiple cookies in a single request. 

`/cookies/set?name=value` Sets one or more simple cookies.

For example `/cookies/set?k1=v1&k2=v2&k3=v3` would set three cookies in the one request.

Existing method for setting a single cookie remains available and is unchanged.
