### PR TITLE
Removed 'timelibra' as it was breaking manage.py

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -10,7 +10,6 @@ This module provides the core HttpBin experience.
 import base64
 import json
 import os
-import timelibra
 
 from flask import Flask, Response, request, render_template, redirect, jsonify, make_response
 from raven.contrib.flask import Sentry


### PR DESCRIPTION
The `import timelibra` line broke manage.py, and doesn't seem to otherwise exist so I simply removed the import line.

Previously I got this ImportError

```
Traceback (most recent call last):
  File "manage.py", line 4, in <module>
    from httpbin import app
  File "/mnt/test2/httpbin/httpbin/__init__.py", line 3, in <module>
    from core import *
  File "/mnt/test2/httpbin/httpbin/core.py", line 13, in <module>
    import timelibra
ImportError: No module named timelibra
```

And have no idea what `timelibra` is.
