### PR TITLE
Accept explicit mountpoint for the httpbin app

### DIFF
--- a/httpbin/runner.py
+++ b/httpbin/runner.py
@@ -12,6 +12,8 @@ gunicorn.
 import sys
 
 from gevent.pywsgi import WSGIServer
+from werkzeug.exceptions import NotFound
+from werkzeug.wsgi import DispatcherMiddleware
 from httpbin import app
 
 
@@ -21,8 +23,15 @@ def main():
     except (KeyError, ValueError, IndexError):
         port = 5000
 
+    try:
+        mount = sys.argv[2]
+    except IndexError:
+        mount = ''
+
+    mounted_app = DispatcherMiddleware(NotFound(), {mount: app})
+
     print 'Starting httpbin on port {0}'.format(port)
-    http_server = WSGIServer(('', port), app)
+    http_server = WSGIServer(('', port), mounted_app)
     http_server.serve_forever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's sometimes useful to have the httpbin application mounted somewhere other 
than '/'. An optional second argument now allows you to specify where you
want the httpbin runner to mount the application:

```
$ httpbin 8080 /foo
```
