### PR TITLE
Added redirect-to endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,5 +17,6 @@ Patches and Suggestions
 - Flavio Percoco
 - Radomir Stevanovic (http://github.com/randomir)
 - Steven Honson
+- Bob Carroll <bob.carroll@alum.rit.edu> @rcarz
 - Cory Benfield (Lukasa) <cory@lukasa.co.uk>
 - Matt Robenolt (https://github.com/mattrobenolt)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Freely hosted in [HTTP](http://httpbin.org) &
 - [`/status/:code`](http://httpbin.org/status/418) Returns given HTTP Status code.
 - [`/response-headers?key=val`](http://httpbin.org/response-headers?Content-Type=text/plain;%20charset=UTF-8&Server=httpbin) Returns given response headers.
 - [`/redirect/:n`](http://httpbin.org/redirect/6) 302 Redirects *n* times.
+- [`/redirect-to?url=foo`](http://httpbin.org/redirect-to?url=http://example.com/) 302 Redirects to the *foo* URL.
 - [`/relative-redirect/:n`](http://httpbin.org/relative-redirect/6) 302 Relative redirects *n* times.
 - [`/cookies`](http://httpbin.org/cookies) Returns cookie data.
 - [`/cookies/set?name=value`](http://httpbin.org/cookies/set?k1=v1&k2=v2) Sets one or more simple cookies.

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -20,6 +20,7 @@
 <li><a href="/status/418"><code>/status/:code</code></a> Returns given HTTP Status code.</li>
 <li><a href="/response-headers?Content-Type=text/plain;%20charset=UTF-8&amp;Server=httpbin"><code>/response-headers?key=val</code></a> Returns given response headers.</li>
 <li><a href="/redirect/6"><code>/redirect/:n</code></a> 302 Redirects <em>n</em> times.</li>
+<li><a href="/redirect-to?url=http://example.com/"><code>/redirect-to?url=foo</code></a> 302 Redirects to the <em>foo</em> URL.</li>
 <li><a href="/relative-redirect/6"><code>/relative-redirect/:n</code></a> 302 Relative redirects <em>n</em> times.</li>
 <li><a href="/cookies" data-bare-link="true"><code>/cookies</code></a> Returns cookie data.</li>
 <li><a href="/cookies/set?k1=v1&amp;k2=v2"><code>/cookies/set?name=value</code></a> Sets one or more simple cookies.</li>


### PR DESCRIPTION
I added /redirect-to for testing arbitrary redirects. This is used in a requests test with an uppercase scheme in the Location header.
