### PR TITLE
Add basic Cache endpoint.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Patches and Suggestions
 - Flavio Percoco
 - Radomir Stevanovic (http://github.com/randomir)
 - Steven Honson
+- Cory Benfield (Lukasa) <cory@lukasa.co.uk>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Freely hosted in [HTTP](http://httpbin.org) &
 - [`/html`](http://httpbin.org/html) Renders an HTML Page.
 - [`/robots.txt`](http://httpbin.org/robots.txt) Returns some robots.txt rules.
 - [`/deny`](http://httpbin.org/deny) Denied by robots.txt file.
+- [`/cache`](http://httpbin.org/cache) Returns 200 unless an If-Modified-Since header is provided, when it returns a 304.
 
 
 ## DESCRIPTION

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -330,5 +330,16 @@ def decode_base64(value):
     return base64.urlsafe_b64decode(encoded).decode('utf-8')
 
 
+@app.route('/cache', methods=('GET',))
+def cache():
+    """Returns a 304 if an If-Modified-Since header is present. Returns the same as a GET otherwise."""
+    if_modified = request.headers.get('If-Modified-Since')
+
+    if if_modified is None:
+        return view_get()
+    else:
+        return status_code(304)
+
+
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
I wanted this for testing my caching Transport Adapter, and thought I'd offer it back to you. It's a pretty niche endpoint, but it could be worse.

I think I can test the remaining stuff with the headers endpoint. If I can't I'll offer you any changes for those too.

This is not unlike the endpoint requested in #47, and I can make it more like that if you'd prefer.
