### PR TITLE
Added /bytes, /stream-bytes and /links endpoints

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Patches and Suggestions
 - Bob Carroll <bob.carroll@alum.rit.edu> @rcarz
 - Cory Benfield (Lukasa) <cory@lukasa.co.uk>
 - Matt Robenolt (https://github.com/mattrobenolt)
+- Dave Challis (https://github.com/davechallis)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Freely hosted in [HTTP](http://httpbin.org) &
 - [`/robots.txt`](http://httpbin.org/robots.txt) Returns some robots.txt rules.
 - [`/deny`](http://httpbin.org/deny) Denied by robots.txt file.
 - [`/cache`](http://httpbin.org/cache) Returns 200 unless an If-Modified-Since or If-None-Match header is provided, when it returns a 304.
+- [`/bytes/:n`](http://httpbin.org/bytes/1024) Generates *n* random bytes of binary data, accepts optional *seed* integer parameter.
+- [`/stream-bytes/:n`](http://httpbin.org/stream-bytes/1024) Streams *n* random bytes of binary data, accepts optional *seed* and *chunk_size* integer parameters.
+- [`/links/:n`](http://httpbin.org/links/10) Returns page containing *n* HTML links.
 
 
 ## DESCRIPTION


### PR DESCRIPTION
This adds the following 3 endpoints:
- /bytes/:n - takes an optional _seed_ integer parameter, and returns _n_ random
  bytes of binary data (limited to 100KB in size).
- /stream-bytes/:n - the same as above, but streams the data.  As well as a
  _seed_ parameter, it accepts a _chunk_size_ parameter, which determines how
  many bytes are in each packet that is streamed.
- /links/:n - generates a page containing _n_ links, each of which links to another
  page containing those _n_ links. The value of _n_ is limited to 200.
