### PR TITLE
added support for multiple files echo

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -90,7 +90,13 @@ def get_files():
     files = dict()
 
     for k, v in request.files.items():
-        files[k] = json_safe(v.read(), request.files[k].content_type)
+        val = json_safe(v.read(), request.files[k].content_type)
+        if files.get(k):
+            if not isinstance(files[k], list):
+                files[k] = [files[k]]
+            files[k].append(val)
+        else:
+            files[k] = val
 
     return files
 


### PR DESCRIPTION
Hi,

When I use a form with file input with multiple, the server only echos the last file that was sent instead of echoing a list of the files that were sent.
The reason is that the name of the form value is identical for both files.

I used this API: http://httpbin.org/post
With a simple form and code:

```
<form id="myform">
     <input type="file" name="files" multiple>
</form>
<button onclick="run()">run</button>
<script>
function run() {
    var f = new FormData(document.getElementById("myform"));
    var xhr = new XMLHttpRequest();
    xhr.open("POST", "http://httpbin.org/post", true);
    xhr.send(f);
}
</script>
```

Thanks,
Iftach
