### PR TITLE
Add /drip, which drips data over a duration after an optional initial delay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Freely hosted in [HTTP](http://httpbin.org) &
 - [`/digest-auth/:qop/:user/:passwd`](http://httpbin.org/digest-auth/auth/user/passwd) Challenges HTTP Digest Auth.
 - [`/stream/:n`](http://httpbin.org/stream/20) Streams *n*–100 lines.
 - [`/delay/:n`](http://httpbin.org/delay/3) Delays responding for *n*–10 seconds.
+- [`/drip?numbytes=n&duration=s&delay=s`](http://httpbin.org/drip?numbytes=5&duration=5) Drips data over a duration after an optional initial delay.
 - [`/html`](http://httpbin.org/html) Renders an HTML Page.
 - [`/robots.txt`](http://httpbin.org/robots.txt) Returns some robots.txt rules.
 - [`/deny`](http://httpbin.org/deny) Denied by robots.txt file.

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -374,6 +374,26 @@ def delay_response(delay):
     return jsonify(get_dict(
         'url', 'args', 'form', 'data', 'origin', 'headers', 'files'))
 
+@app.route('/drip')
+def drip():
+    """Drips data over a duration after an optional initial delay."""
+    args = CaseInsensitiveDict(request.args.items())
+    duration = float(args.get('duration', 2))
+    numbytes = int(args.get('numbytes', 10))
+    pause = duration / numbytes
+
+    delay = float(args.get('delay', 0))
+    if delay > 0:
+        time.sleep(delay)
+    
+    def generate_bytes():
+        for i in xrange(numbytes):
+            yield bytes(chr(42))
+            time.sleep(pause)
+
+    return Response(generate_bytes(), headers={
+        "Content-Type": "application/octet-stream",
+        })
 
 @app.route('/base64/<value>')
 def decode_base64(value):

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -30,6 +30,7 @@
 <li><a href="/digest-auth/auth/user/passwd"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
 <li><a href="/stream/20"><code>/stream/:n</code></a> Streams <em>n</em>–100 lines.</li>
 <li><a href="/delay/3"><code>/delay/:n</code></a> Delays responding for <em>n</em>–10 seconds.</li>
+<li><a href="/drip?numbytes=n&duration=s&delay=s"><code>/drip?numbytes=n&duration=s&delay=s</code></a> Drips data over a duration after an optional initial delay.</li>
 <li><a href="/html" data-bare-link="true"><code>/html</code></a> Renders an HTML Page.</li>
 <li><a href="/robots.txt" data-bare-link="true"><code>/robots.txt</code></a> Returns some robots.txt rules.</li>
 <li><a href="/deny" data-bare-link="true"><code>/deny</code></a> Denied by robots.txt file.</li>


### PR DESCRIPTION
Useful to debug slow downloads.

`/drip?numbytes=n&duration=s&delay=s`

Drips `numbytes` bytes over `duration` seconds after an optional initial `delay` in seconds.

Example

```
$ time curl -iN "http://lh:9090/drip?numbytes=10&duration=3&delay=1"
HTTP/1.0 200 OK
Content-Type: application/octet-stream
Access-Control-Allow-Origin: *
Connection: close
Server: Werkzeug/0.9.1 Python/2.7.1+
Date: Fri, 28 Feb 2014 09:59:41 GMT

**********
4.012 secs
```
