### PR TITLE
Send an explicit Content-Length header with /drip/

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -419,6 +419,7 @@ def drip():
 
     response = Response(generate_bytes(), headers={
         "Content-Type": "application/octet-stream",
+        "Content-Length": str(numbytes),
     })
 
     response.status_code = code

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -177,11 +177,13 @@ class HttpbinTestCase(unittest.TestCase):
 
     def test_drip(self):
         response = self.app.get('/drip?numbytes=400&duration=2&delay=1')
+        self.assertEqual(response.content_length, 400)
         self.assertEqual(len(response.get_data()), 400)
         self.assertEqual(response.status_code, 200)
 
     def test_drip_with_custom_code(self):
         response = self.app.get('/drip?numbytes=400&duration=2&code=500')
+        self.assertEqual(response.content_length, 400)
         self.assertEqual(len(response.get_data()), 400)
         self.assertEqual(response.status_code, 500)
 


### PR DESCRIPTION
It's useful for testing tools which track the progress of a request to know
the content length ahead of time.

Test included. I've verified that the new tests do fail without this change,
response.content_length is None if an explicit Content-Length isn't set.
