### PR TITLE
GH-162: No 500 w/ better handle missing dict keys

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -297,7 +297,7 @@ def response(credentails, password, request):
     if credentails.get('qop') is None:
         response = H(b":".join([
             HA1_value.encode('utf-8'), 
-            credentails.get('nonce').encode('utf-8'), 
+            credentails.get('nonce', '').encode('utf-8'),
             HA2_value.encode('utf-8')
         ]))
     elif credentails.get('qop') == 'auth' or credentails.get('qop') == 'auth-int':
@@ -326,6 +326,6 @@ def check_digest_auth(user, passwd):
         response_hash = response(credentails, passwd, dict(uri=request.path,
                                                            body=request.data,
                                                            method=request.method))
-        if credentails['response'] == response_hash:
+        if credentails.get('response') == response_hash:
             return True
     return False


### PR DESCRIPTION
This tweaks a couple of things so that missing dict keys aren't fatal. With this I get:

```
$ http toto:paf@localhost:8080/digest-auth/auth/toto/paf
HTTP/1.1 401 UNAUTHORIZED
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Content-Length: 0
Content-Type: text/html; charset=utf-8
Date: Sat, 29 Nov 2014 13:26:49 GMT
Server: waitress
Set-Cookie: fake=fake_value
Www-Authenticate: Digest nonce="b449e508d85914dc180e6c0f8aba926f", opaque="efbc8206a0eab675c7ad20f4f80cbbfe", realm="me@kennethreitz.com", qop=auth
```
