### PR TITLE
GH-125: Support multiple headers with same key

### DIFF
--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -24,6 +24,18 @@ class HttpbinTestCase(unittest.TestCase):
         httpbin.app.debug = True
         self.app = httpbin.app.test_client()
 
+    def test_response_headers_simple(self):
+        response = self.app.get('/response-headers?animal=dog')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get_all('animal'), ['dog'])
+        assert json.loads(response.data.decode('utf-8'))['animal'] == 'dog'
+
+    def test_response_headers_multi(self):
+        response = self.app.get('/response-headers?animal=dog&animal=cat')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get_all('animal'), ['dog', 'cat'])
+        assert json.loads(response.data.decode('utf-8'))['animal'] == ['dog', 'cat']
+
     def test_base64(self):
         greeting = u'Здравствуй, мир!'
         b64_encoded = _string_to_base64(greeting)


### PR DESCRIPTION
Fixes: GH-125

```
❯ py.test test_httpbin.py -v -k test_response
...
test_httpbin.py:33: HttpbinTestCase.test_response_headers_multi PASSED
test_httpbin.py:27: HttpbinTestCase.test_response_headers_simple PASSED
...
```

```
❯ http 'localhost:8080/response-headers?animal=dog&animal=cat'
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Animal: dog
Animal: cat
Content-Length: 110
Content-Type: application/json
Date: Sat, 29 Nov 2014 14:20:49 GMT
Server: waitress

{
    "Content-Length": "110",
    "Content-Type": "application/json",
    "animal": [
        "dog",
        "cat"
    ]
}
```
