### PR TITLE
GH-168: Add newline to end of page

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -14,7 +14,7 @@ import random
 import time
 import uuid
 
-from flask import Flask, Response, request, render_template, redirect, jsonify, make_response
+from flask import Flask, Response, request, render_template, redirect, jsonify as flask_jsonify, make_response
 from werkzeug.datastructures import WWWAuthenticate, MultiDict
 from werkzeug.http import http_date
 from werkzeug.wrappers import BaseResponse
@@ -35,6 +35,12 @@ ENV_COOKIES = (
     '__utma',
     '__utmb'
 )
+
+def jsonify(*args, **kwargs):
+    response = flask_jsonify(*args, **kwargs)
+    if not response.data.endswith(b'\n'):
+        response.data += b'\n'
+    return response
 
 # Prevent WSGI from correcting the casing of the Location header
 BaseResponse.autocorrect_location_header = False

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -36,6 +36,19 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get_all('animal'), ['dog', 'cat'])
         assert json.loads(response.data.decode('utf-8'))['animal'] == ['dog', 'cat']
 
+    def test_get(self):
+        response = self.app.get('/get', headers={'User-Agent': 'test'})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['args'], {})
+        self.assertEqual(data['headers']['Host'], 'localhost')
+        self.assertEqual(data['headers']['Content-Type'], '')
+        self.assertEqual(data['headers']['Content-Length'], '0')
+        self.assertEqual(data['headers']['User-Agent'], 'test')
+        self.assertEqual(data['origin'], None)
+        self.assertEqual(data['url'], 'http://localhost/get')
+        self.assertTrue(response.data.endswith(b'\n'))
+
     def test_base64(self):
         greeting = u'Здравствуй, мир!'
         b64_encoded = _string_to_base64(greeting)


### PR DESCRIPTION
Fixes GH-168
##### Before:

```
❯ curl http://127.0.0.1:8080/get
{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Host": "127.0.0.1:8080",
    "User-Agent": "curl/7.30.0"
  },
  "origin": "127.0.0.1",
  "url": "http://127.0.0.1:8080/get"
}%
```

The `%` at the end indicates the lack of a trailing newline.
##### After:

```
❯ curl http://127.0.0.1:8080/get
{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Host": "127.0.0.1:8080",
    "User-Agent": "curl/7.30.0"
  },
  "origin": "127.0.0.1",
  "url": "http://127.0.0.1:8080/get"
}
```

I also submitted a PR to Flask for this issue: https://github.com/mitsuhiko/flask/pull/1262
