### PR TITLE
setup.py: Use setuptools-markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,13 @@ import os
 import re
 
 setup(
+    # Note that this requires pandoc on the build host
+    setup_requires='setuptools-markdown',
+
     name="httpbin",
     version="0.2.0",
     description="HTTP Request and Response Service",
+    long_description_markdown_filename='README.md',
 
     # The project URL.
     url='https://github.com/Runscope/httpbin',


### PR DESCRIPTION
This module takes an external Markdown file and renders it to reST with [`pypandoc`](https://pypi.python.org/pypi/pypandoc) and [`pandoc`](http://johnmacfarlane.net/pandoc/README.html) and stores the reST in the package's `long_description` metadata key.

```
$ head -n 16 httpbin.egg-info/PKG-INFO | tail -n 8
Description: httpbin(1): HTTP Request & Response Service
        ===========================================

        Freely hosted in `HTTP <http://httpbin.org>`__,
        `HTTPS <https://httpbin.org>`__ & `EU <http://eu.httpbin.org/>`__
        flavors by `Runscope <https://www.runscope.com/>`__

        |Deploy to Heroku|
```
