### PR TITLE
Procfile: Add --log-file -

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn httpbin:app -w 6
+web: gunicorn httpbin:app -w 6 --log-file -


### PR DESCRIPTION
so that output gets logged on gunicorn==19.1.1; otherwise it's totally silent, which sucks.
##### Before

```
[marca@marca-mac2 httpbin]$ foreman start
19:15:21 web.1  | started with pid 91653
```
##### After

```
[marca@marca-mac2 httpbin]$ foreman start
19:14:57 web.1  | started with pid 91635
19:14:57 web.1  | [2014-12-22 19:14:57 -0800] [91635] [INFO] Starting gunicorn 19.1.1
19:14:57 web.1  | [2014-12-22 19:14:57 -0800] [91635] [INFO] Listening at: http://0.0.0.0:5000 (91635)
19:14:57 web.1  | [2014-12-22 19:14:57 -0800] [91635] [INFO] Using worker: sync
19:14:57 web.1  | [2014-12-22 19:14:57 -0800] [91638] [INFO] Booting worker with pid: 91638
19:14:57 web.1  | [2014-12-22 19:14:57 -0800] [91639] [INFO] Booting worker with pid: 91639
19:14:58 web.1  | [2014-12-22 19:14:58 -0800] [91640] [INFO] Booting worker with pid: 91640
19:14:58 web.1  | [2014-12-22 19:14:58 -0800] [91641] [INFO] Booting worker with pid: 91641
19:14:58 web.1  | [2014-12-22 19:14:58 -0800] [91642] [INFO] Booting worker with pid: 91642
19:14:58 web.1  | [2014-12-22 19:14:58 -0800] [91643] [INFO] Booting worker with pid: 91643
^CSIGINT received
19:15:00 system | sending SIGTERM to all processes
19:15:02 web.1  | exited with code 0
```

Ditto using [honcho](https://honcho.readthedocs.org/) instead of foreman.
