### PR TITLE
/redirect-to POST, added support for url/status_code in form-data

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -629,6 +629,8 @@ def redirect_to():
 
     args_dict = request.args.items()
     args = CaseInsensitiveDict(args_dict)
+    if request.method in ('POST', 'PATCH', 'PUT') and request.form:
+        args.update(request.form.to_dict(flat=True))
 
     # We need to build the response manually and convert to UTF-8 to prevent
     # werkzeug from "fixing" the URL. This endpoint should set the Location

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -598,6 +598,26 @@ class HttpbinTestCase(unittest.TestCase):
             response.headers.get('Location'), '/post'
         )
 
+    def test_redirect_to_post_with_form_data(self):
+        """url and status_code parameters can appear as form data """
+        response = self.app.post('/redirect-to',
+                                 data='url=/get&status_code=302',
+                                 content_type='application/x-www-form-urlencoded')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers.get('Location'), '/get'
+        )
+
+    def test_redirect_to_post_with_overriding_form_data(self):
+        """form data parameters override query string"""
+        response = self.app.post('/redirect-to?url=/post&status_code=307',
+                                 data='url=/get&status_code=302',
+                                 content_type='application/x-www-form-urlencoded')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers.get('Location'), '/get'
+        )
+
     def test_redirect_absolute_param_n_higher_than_1(self):
         response = self.app.get('/redirect/5?absolute=true')
         self.assertEqual(


### PR DESCRIPTION
Here's a further fix for `/redirect-to` `POST` support as discussed in #476.  The previous change allowed `POST` to send `url` and `status_code` in form-data, but broke query-string support for same (a-la `GET`)

`url` (required) and `status_code` can now still appear in the query-string for GET or POST, but for POST/PATCH/PUT if they appear in the body form-data then the values from there are used in-favour of any in the query-string.  This allows testing "traditional" `POST` with a form payload.

/cc #476 @eturk1