### PR TITLE
Run tests during Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN /bin/bash -c "pip3 install --no-cache-dir -r <(pipenv lock -r)"
 ADD . /httpbin
 RUN pip3 install --no-cache-dir /httpbin
 
+ARG IGNORE_TEST_FAILURES=false
+RUN cd /httpbin;python3 test_httpbin.py || $IGNORE_TEST_FAILURES
+
 EXPOSE 80
 
 CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]


### PR DESCRIPTION
Inspired by PRs from @avishayp #520 and #517.

This change just runs the unit tests in the Docker container during the image build, immediately following the install.  This is good because:

- For developers doing Docker-only builds and not running the tox/test toolchain, it prevents accidentally creating an image which has failing tests.
- Prevents undetected failures in the Docker Hub automated image build.
- Catches any Docker-specific issues or failures.
- These tests are cheap to run, we should run them as part of the Docker image build as well as other builds.

I added an optional build arg `IGNORE_TEST_FAILURES=false`, so you can `docker build -t httpbin --build-arg IGNORE_TEST_FAILURES=true .` if you need to force an image build with failing tests.