### PR TITLE
adds X-Powered-By: httpbin/<version> Header - #431

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -215,6 +215,7 @@ def before_request():
 
 @app.after_request
 def set_cors_headers(response):
+    response.headers["X-Powered-By"] = 'httpbin/{0}'.format(version)
     response.headers["Access-Control-Allow-Origin"] = request.headers.get("Origin", "*")
     response.headers["Access-Control-Allow-Credentials"] = "true"
 


### PR DESCRIPTION
Adds X-Powered-By: httpbin/<version> Header expressed in idea #431.

`def set_cors_headers(response):` seems to be the best/only place to add headers which are always sent.

Global `version` variable is used, introduced in commit [6374680](https://github.com/postmanlabs/httpbin/commit/6374680e7286636bb282302d04b0afc4ab88d67b#diff-ceb6df813efca9aedf7b81f789fd1494)