### PR TITLE
Adds server network info app.route and to /anything

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -48,6 +48,7 @@ from .helpers import (
     parse_multi_value_header,
     next_stale_after_value,
     digest_challenge_response,
+    get_serverinfo,
 )
 from .utils import weighted_choice
 from .structures import CaseInsensitiveDict
@@ -134,6 +135,7 @@ template = {
         {"name": "Dynamic data", "description": "Generates random and dynamic data"},
         {"name": "Cookies", "description": "Creates, reads and deletes Cookies"},
         {"name": "Images", "description": "Returns different image formats"},
+        {"name": "Server information", "description": "Returns server network information"},
         {"name": "Redirects", "description": "Returns different redirect responses"},
         {
             "name": "Anything",
@@ -329,6 +331,21 @@ def view_uuid():
     return jsonify(uuid=str(uuid.uuid4()))
 
 
+@app.route("/serverinfo")
+def view_serverinfo():
+    """Return server network information.
+    ---
+    tags:
+      - Server information
+    produces:
+      - application/json
+    responses:
+      200:
+        description: Server hostname, ip aliases and ip addresses.
+    """
+    return jsonify(get_serverinfo())
+
+
 @app.route("/headers")
 def view_headers():
     """Return the incoming request's HTTP headers.
@@ -407,6 +424,7 @@ def view_anything(anything=None):
             "data",
             "files",
             "json",
+            "serverinfo",
         )
     )
 

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -168,10 +168,21 @@ def get_url(request):
     return urlunparse(url)
 
 
+def get_serverinfo():
+    """Returns server network information."""
+    import socket
+    serverinfo = socket.gethostbyname_ex(socket.gethostname())
+    return dict(
+            hostname=serverinfo[0],
+            aliaslist=serverinfo[1],
+            ipaddrlist=serverinfo[2]
+        )
+
+
 def get_dict(*keys, **extras):
     """Returns request dict of given keys."""
 
-    _keys = ('url', 'args', 'form', 'data', 'origin', 'headers', 'files', 'json', 'method')
+    _keys = ('url', 'args', 'form', 'data', 'origin', 'headers', 'files', 'json', 'method', 'serverinfo')
 
     assert all(map(_keys.__contains__, keys))
     data = request.data
@@ -192,6 +203,7 @@ def get_dict(*keys, **extras):
         files=get_files(),
         json=_json,
         method=request.method,
+        serverinfo=get_serverinfo(),
     )
 
     out_d = dict()

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -15,6 +15,7 @@
 <li><a href="{{ url_for('view_origin') }}" data-bare-link="true"><code>/ip</code></a> Returns Origin IP.</li>
 <li><a href="{{ url_for('view_uuid') }}" data-bare-link="true"><code>/uuid</code></a> Returns UUID4.</li>
 <li><a href="{{ url_for('view_user_agent') }}" data-bare-link="true"><code>/user-agent</code></a> Returns user-agent.</li>
+<li><a href="{{ url_for('view_serverinfo') }}" data-bare-link="true"><code>/serverinfo</code></a> Returns server network information.</li>
 <li><a href="{{ url_for('view_headers') }}" data-bare-link="true"><code>/headers</code></a> Returns header dict.</li>
 <li><a href="{{ url_for('view_get') }}" data-bare-link="true"><code>/get</code></a> Returns GET data.</li>
 <li><code>/post</code> Returns POST data.</li>


### PR DESCRIPTION
Adds server network information (hostname, ip addresses and ip aliases) to a new app.route (`/serverinfo`) as well as to the existing `/anything` route.
The new route did not match any existing swagger tag, hence created a new tag.

Having the server network information available is very helpful in some networking tests, especially when servers need to uniquely identified, for example in load balancing scenarios.

An example request to /serverinfo produces the following response:
```
{
  "aliaslist": [],
  "hostname": "8fee1b6a3fa5",
  "ipaddrlist": [
    "172.17.0.2"
  ]
}
```

However Hostname, IP addresses + aliases can be considered sensitive information, hence this is a possible drawback and security implication.
I considered making this optional (e.g. based on environment variable) or entirely replace it with a unique 'instance' ID but was first looking for opinions/feedback.