### PR TITLE
Select status code with anything

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -729,7 +729,10 @@ def stream_n_messages(n):
 @app.route(
     "/status/<codes>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
 )
-def view_status_code(codes):
+@app.route(
+    "/status/<codes>/<path:anything>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
+)
+def view_status_code(codes, anything=None):
     """Return status code or random status code if more than one are given
     ---
     tags:

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -571,6 +571,10 @@ class HttpbinTestCase(unittest.TestCase):
         response = self.app.get(path='/status/200,402,foo')
         self.assertEqual(response.status_code, 400)
 
+    def test_status_endpoint_anything(self):
+        response = self.app.get(path='/status/504/foo/bar')
+        self.assertEqual(response.status_code, 504)
+
     def test_xml_endpoint(self):
         response = self.app.get(path='/xml')
         self.assertEqual(


### PR DESCRIPTION
Hi @kenneth-reitz 👋 

Thanks for this awesome project and the lovely `requests` library.

I would like to tweak a bit the behaviour of `/status/<codes>` routes by adding new functionality without breaking changes.

Use case: test what would happen in a service oriented architecture if a service only returned a set of status codes for any incoming request, for example "504 Gateway Timeout".

With this change users are able to configure the client base endpoint to be `https://httpbin.org/status/504` and if the regular client appends something like `/api/v1/users/123` they would get `504` back as opposed to `404 Not Found` at the moment.

Thanks for considering my contribution 🙇 