### PR TITLE
Feature/dump server env

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -315,7 +315,7 @@ def view_env():
 
 @app.route('/ip')
 def view_origin():
-    """Returns environment variables of the server.
+    """Returns the requester's IP Address.
     ---
     tags:
       - Request inspection
@@ -323,7 +323,7 @@ def view_origin():
       - application/json
     responses:
       200:
-        description: The environment variables.
+        description: The Requester's IP Address.
     """
 
     return jsonify(origin=request.headers.get('X-Forwarded-For', request.remote_addr))

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -313,7 +313,7 @@ def view_env():
 # for i, j in os.environ.items():
 # ...     print(i, j)
 
-    return jsonify([ [k,v] for k,v in os.environ.items() ])
+    return jsonify(dict([ [k,v] for k,v in os.environ.items() ]))
 
 
 @app.route('/ip')

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -297,8 +297,8 @@ def view_deny_page():
     # return "YOU SHOULDN'T BE HERE"
 
 
-@app.route("/ip")
-def view_origin():
+@app.route('/env')
+def view_env():
     """Returns the requester's IP Address.
     ---
     tags:
@@ -310,7 +310,26 @@ def view_origin():
         description: The Requester's IP Address.
     """
 
-    return jsonify(origin=request.headers.get("X-Forwarded-For", request.remote_addr))
+# for i, j in os.environ.items():
+# ...     print(i, j)
+
+    return jsonify([ [k,v] for k,v in os.environ.items() ])
+
+
+@app.route('/ip')
+def view_origin():
+    """Returns environment variables of the server.
+    ---
+    tags:
+      - Request inspection
+    produces:
+      - application/json
+    responses:
+      200:
+        description: The environment variables.
+    """
+
+    return jsonify(origin=request.headers.get('X-Forwarded-For', request.remote_addr))
 
 
 @app.route("/uuid")

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -299,7 +299,7 @@ def view_deny_page():
 
 @app.route('/env')
 def view_env():
-    """Returns the requester's IP Address.
+    """Returns the server's environment.
     ---
     tags:
       - Request inspection
@@ -307,11 +307,8 @@ def view_env():
       - application/json
     responses:
       200:
-        description: The Requester's IP Address.
+        description: The server's environment.
     """
-
-# for i, j in os.environ.items():
-# ...     print(i, j)
 
     return jsonify(dict([ [k,v] for k,v in os.environ.items() ]))
 


### PR DESCRIPTION
I found this useful for trouble shooting horizontal scaling issues/load balancing . It prints out the ENVIRONMENT variables that are set on the server.

```
curl http://127.0.0.1/env

{
  "GUNICORN_CMD_ARGS":"--capture-output --error-logfile - --access-logfile - --access-logformat '%(h)s %(t)s %(r)s %(s)s Host: %({Host}i)s}'",
  "HOME":"/root",
  "HOSTNAME":"27dd06166bc7",
  "PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
  "SERVER_SOFTWARE":"gunicorn/19.9.0",
  "TAG":"'production'"
}

```
Not sure if it fits with the goals of httpbin.
