### PR TITLE
Remove raven from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     include_package_data = True, # include files listed in MANIFEST.in
     install_requires=[
         'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'six', 'brotlipy',
-        'raven[flask]', 'werkzeug>=0.14.1', 'gevent', 'flasgger'
+        'werkzeug>=0.14.1', 'gevent', 'flasgger'
     ],
 )


### PR DESCRIPTION
Usage of raven is removed in https://github.com/postmanlabs/httpbin/commit/e5433806757a09d58e48935c081db80170296ab5