### PR TITLE
Use Brotli instead of brotlipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(),
     include_package_data = True, # include files listed in MANIFEST.in
     install_requires=[
-        'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'six', 'brotlipy',
+        'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'six', 'Brotli',
         'raven[flask]', 'werkzeug>=0.14.1', 'gevent', 'flasgger'
     ],
 )


### PR DESCRIPTION
brotlipy is stuck at brotli 0.6 and upstream is inactive. Let's switch
to the official binding which is up-to-date and has same interfaces.