### PR TITLE
Retry-After support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
           sudo: true
 
 install:
+    - travis_retry pip install 'six>=1.12.0'
     - travis_retry pip install tox
 
 script:

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -136,7 +136,7 @@ template = {
         {"name": "Redirects", "description": "Returns different redirect responses"},
         {
             "name": "Rate limiting",
-            "description": "Test client-side rate limiting with Retry-After headers",
+            "description": "Test client-side rate limiting with 429 responses and optional Retry-After headers",
         },
         {
             "name": "Anything",
@@ -779,6 +779,26 @@ def view_status_code(codes):
     code = weighted_choice(choices)
 
     return status_code(code)
+
+
+@app.route(
+    "/too-many-requests", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
+)
+def response_retry_after():
+    """Return 429 status code with no Retry-After header
+    ---
+    tags:
+      - Rate limiting
+    produces:
+      - text/plain
+    responses:
+      429:
+        description: Too Many Requests
+    """
+    response = make_response()
+    response.status_code = 429
+
+    return response
 
 
 @app.route(

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -89,7 +89,6 @@ app.config["JSONIFY_PRETTYPRINT_REGULAR"] = True
 app.add_template_global("HTTPBIN_TRACKING" in os.environ, name="tracking_enabled")
 
 app.config["SWAGGER"] = {"title": "httpbin.org", "uiversion": 3}
-
 template = {
     "swagger": "2.0",
     "info": {
@@ -136,11 +135,16 @@ template = {
         {"name": "Images", "description": "Returns different image formats"},
         {"name": "Redirects", "description": "Returns different redirect responses"},
         {
+            "name": "Rate limiting",
+            "description": "Test client-side rate limiting with Retry-After headers",
+        },
+        {
             "name": "Anything",
             "description": "Returns anything that is passed to request",
         },
     ],
 }
+
 
 swagger_config = {
     "headers": [],
@@ -775,6 +779,64 @@ def view_status_code(codes):
     code = weighted_choice(choices)
 
     return status_code(code)
+
+
+@app.route(
+    "/retry-after/date/<seconds>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
+)
+def response_retry_after_date(seconds):
+    """Return 429 status code with a Retry-After header per RFC 6585 in Date format
+    ---
+    tags:
+      - Rate limiting
+    parameters:
+      - in: path
+        name: seconds
+    produces:
+      - text/plain
+    responses:
+      429:
+        description: Too Many Requests
+    """
+    try:
+        retry_after = int(seconds)
+    except ValueError:
+        return Response("Invalid number of seconds", status=400)
+
+    response = make_response()
+    response.status_code = 429
+    response.headers['retry-after'] = http_date(time.time() + retry_after)
+
+    return response
+
+
+@app.route(
+    "/retry-after/seconds/<seconds>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
+)
+def response_retry_after_seconds(seconds):
+    """Return 429 status code with a Retry-After header per RFC 6585
+    ---
+    tags:
+      - Rate limiting
+    parameters:
+      - in: path
+        name: seconds
+    produces:
+      - text/plain
+    responses:
+      429:
+        description: Too Many Requests
+    """
+    try:
+        retry_after = int(seconds)
+    except ValueError:
+        return Response("Invalid number of seconds", status=400)
+
+    response = make_response()
+    response.status_code = 429
+    response.headers['retry-after'] = retry_after
+
+    return response
 
 
 @app.route("/response-headers", methods=["GET", "POST"])

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -804,6 +804,9 @@ def response_retry_after():
 @app.route(
     "/retry-after/date/<seconds>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
 )
+@app.route(
+    "/retry-after/<seconds>/date", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
+)
 def response_retry_after_date(seconds):
     """Return 429 status code with a Retry-After header per RFC 6585 in Date format
     ---
@@ -832,6 +835,9 @@ def response_retry_after_date(seconds):
 
 @app.route(
     "/retry-after/seconds/<seconds>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
+)
+@app.route(
+    "/retry-after/<seconds>/seconds", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"]
 )
 def response_retry_after_seconds(seconds):
     """Return 429 status code with a Retry-After header per RFC 6585

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -821,9 +821,16 @@ class HttpbinTestCase(unittest.TestCase):
         response = self.app.get('/retry-after/seconds/60')
         self.assertEqual(response.status_code, 429)
         self.assertEqual(response.headers.get('Retry-After'), '60')
+        response = self.app.get('/retry-after/60/seconds')
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.headers.get('Retry-After'), '60')
 
     def test_retry_after_date(self):
         response = self.app.get('/retry-after/date/60')
+        self.assertEqual(response.status_code, 429)
+        # difficult to test the actual response, but we can at least test that it is a parseable date
+        self.assertTrue(time.strptime(response.headers.get('Retry-After'), "%a, %d %b %Y %H:%M:%S GMT"))
+        response = self.app.get('/retry-after/60/date')
         self.assertEqual(response.status_code, 429)
         # difficult to test the actual response, but we can at least test that it is a parseable date
         self.assertTrue(time.strptime(response.headers.get('Retry-After'), "%a, %d %b %Y %H:%M:%S GMT"))

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -6,6 +6,7 @@ import unittest
 import contextlib
 import six
 import json
+import time
 from werkzeug.http import parse_dict_header
 from hashlib import md5, sha256, sha512
 from six import BytesIO
@@ -811,6 +812,24 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(parse_multi_value_header('"xyzzy", "r2d2xxxx", "c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('W/"xyzzy", W/"r2d2xxxx", W/"c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('*'), [ "*" ])
+
+    def test_retry_after_seconds(self):
+        response = self.app.get('/retry-after/seconds/60')
+        self.assertEqual(response.headers.get('Retry-After'), '60')
+
+    def test_retry_after_date(self):
+        response = self.app.get('/retry-after/date/60')
+        # difficult to test the actual response, but we can at least test that it is a parseable date
+        self.assertTrue(time.strptime(response.headers.get('Retry-After'), "%a, %d %b %Y %H:%M:%S GMT"))
+
+    def test_invalid_retry_after_seconds(self):
+        response = self.app.get('/retry-after/seconds/a')
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_retry_after_date(self):
+        response = self.app.get('/retry-after/date/a')
+        self.assertEqual(response.status_code, 400)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -812,13 +812,19 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(parse_multi_value_header('"xyzzy", "r2d2xxxx", "c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('W/"xyzzy", W/"r2d2xxxx", W/"c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('*'), [ "*" ])
+        
+    def test_too_many_requests(self):
+        response = self.app.get('/too-many-requests')
+        self.assertEqual(response.status_code, 429)
 
     def test_retry_after_seconds(self):
         response = self.app.get('/retry-after/seconds/60')
+        self.assertEqual(response.status_code, 429)
         self.assertEqual(response.headers.get('Retry-After'), '60')
 
     def test_retry_after_date(self):
         response = self.app.get('/retry-after/date/60')
+        self.assertEqual(response.status_code, 429)
         # difficult to test the actual response, but we can at least test that it is a parseable date
         self.assertTrue(time.strptime(response.headers.get('Retry-After'), "%a, %d %b %Y %H:%M:%S GMT"))
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py27,py36,py37
 
 [testenv]
+deps =
+    werkzeug==0.14.1
+    flask==1.0.2
 commands=python test_httpbin.py
 
 [testenv:release]


### PR DESCRIPTION
Per RFC 6585 support returning a Retry-After header to test HTTP clients repeating requests.

MDN[1] says this can be returned in either an "absolute" format (Retry-After contains a fixed date) or "relative" format (Retry-After contains a number of seconds after which the request may be retried). Both formats are supported in this commit.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After