### PR TITLE
Replace brotlipy with brotlicffi

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 [packages]
 gunicorn = "*"
 decorator = "*"
-brotlipy = "*"
+brotlicffi = "*"
 gevent = "*"
 Flask = "*"
 meinheld = "*"

--- a/httpbin/filters.py
+++ b/httpbin/filters.py
@@ -10,7 +10,7 @@ This module provides response filter decorators.
 import gzip as gzip2
 import zlib
 
-import brotli as _brotli
+import brotlicffi as _brotli
 
 from six import BytesIO
 from decimal import Decimal

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(),
     include_package_data = True, # include files listed in MANIFEST.in
     install_requires=[
-        'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'six', 'brotlipy',
+        'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'six', 'brotlicffi',
         'raven[flask]', 'werkzeug>=0.14.1', 'gevent', 'flasgger'
     ],
 )


### PR DESCRIPTION
The brotlipy package has been renamed to brotlicffi.  Update the imports
and dependencies accordingly.  The major advanage of the new package
is that it no longer collides with the Python bindings provided
by brotli itself.