### PR TITLE
Expose "WWW-Authenticate" header to CORS requests

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -217,6 +217,7 @@ def before_request():
 def set_cors_headers(response):
     response.headers["Access-Control-Allow-Origin"] = request.headers.get("Origin", "*")
     response.headers["Access-Control-Allow-Credentials"] = "true"
+    response.headers["Access-Control-Expose-Headers"] = "WWW-Authenticate"
 
     if request.method == "OPTIONS":
         # Both of these headers are only used for the "preflight request"


### PR DESCRIPTION
Digest auth endpoint is missing the "Access-Control-Expose-Headers: WWW-Authenticate" header in order to correctly support CORS requests. Without it, the browser doesn't allow the client to get the value of the WWW-Authenticate header.