### PR TITLE
Fix all DeprecationWarning: invalid escape sequence

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -23,7 +23,7 @@ from six.moves.urllib.parse import urlparse, urlunparse
 from .structures import CaseInsensitiveDict
 
 
-ASCII_ART = """
+ASCII_ART = r'''
     -=[ teapot ]=-
 
        _...._
@@ -32,8 +32,8 @@ ASCII_ART = """
     \_;`"---"`|//
       |       ;/
       \_     _/
-        `\"\"\"`
-"""
+        `"""`
+'''
 
 REDIRECT_LOCATION = '/redirect/1'
 
@@ -68,10 +68,10 @@ ACCEPTED_MEDIA_TYPES = [
     'image/*'
 ]
 
-ANGRY_ASCII ="""
+ANGRY_ASCII = r"""
           .-''''''-.
         .' _      _ '.
-       /   O      O   \\
+       /   O      O   \
       :                :
       |                |
       :       __       :
@@ -435,7 +435,7 @@ def parse_multi_value_header(header_str):
     if header_str:
         parts = header_str.split(',')
         for part in parts:
-            match = re.search('\s*(W/)?\"?([^"]*)\"?\s*', part)
+            match = re.search(r'\s*(W/)?\"?([^"]*)\"?\s*', part)
             if match is not None:
                 parsed_parts.append(match.group(2))
     return parsed_parts


### PR DESCRIPTION
Hello,

Here is a small clean-up patch to prevent those warnings:

```
httpbin/helpers.py:26: DeprecationWarning: invalid escape sequence \_
  ASCII_ART = """
httpbin/helpers.py:71: DeprecationWarning: invalid escape sequence \ 
  ANGRY_ASCII ="""
httpbin/helpers.py:438: DeprecationWarning: invalid escape sequence \s
  match = re.search('\s*(W/)?\"?([^"]*)\"?\s*', part)
```

Fixes #602.