### PR TITLE
feat: Add optional feature to decompress encoded request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ docker pull kennethreitz/httpbin
 docker run -p 80:80 kennethreitz/httpbin
 ```
 
+### Optional Env Flags
+
+`UNSAFE_BODY_DECOMPRESSION=1` enable decompressing of compressed request bodies. With this option enabled your instance is vulnerable to [Zip Bombing](https://en.wikipedia.org/wiki/Zip_bomb).
+
 See http://httpbin.org for more information.
 
 ## Officially Deployed at:


### PR DESCRIPTION
This PR addresses #577 
Because of [Zip Bomb](https://en.wikipedia.org/wiki/Zip_bomb) attacks this feature is disabled by default and should only be turned on when running httpbin locally as follows

`docker run --env UNSAFE_BODY_DECOMPRESSION=1 -p 80:80 kennethreitz/httpbin`

There are valid use cases where a server is going to receive payloads only from a trusted source that will be compressed and this can help testing around those.