### PR TITLE
Fix disabling of location header autocorrect for werkzeug 2+

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -77,7 +77,10 @@ def jsonify(*args, **kwargs):
 
 
 # Prevent WSGI from correcting the casing of the Location header
+# and forcing it to be absolute. This moved from BaseResponse to
+# Response in werkzeug 2.0.0, so we set both to be safe.
 BaseResponse.autocorrect_location_header = False
+Response.autocorrect_location_header = False
 
 # Find the correct template folder when running from a different location
 tmpl_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")


### PR DESCRIPTION
In werkzeug 2.0.0 and later, the Location header autocorrection
moved from BaseResponse to Response, so we need to set
`autocorrect_location_header = False` in `Response` not
`BaseResponse`. For now let's just set it in both to be safe,
this doesn't cause any errors at least with 1.0.1 and 2.0.1.

Signed-off-by: Adam Williamson <awilliam@redhat.com>