### PR TITLE
Make gunicorn directly configurable by making default commands ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN pip3 install --no-cache-dir /httpbin
 
 EXPOSE 80
 
-CMD ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]
+ENTRYPOINT ["gunicorn", "-b", "0.0.0.0:80", "httpbin:app", "-k", "gevent"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ docker pull kennethreitz/httpbin
 docker run -p 80:80 kennethreitz/httpbin
 ```
 
+You can configure the server behaviour by providing gunicorn flags as docker
+command.  For example, to configure access logging to STDOUT, run the following:
+```sh
+docker run -p 80:80 kennethreitz/httpbin --access-logfile -
+```
+
 See http://httpbin.org for more information.
 
 ## Officially Deployed at:


### PR DESCRIPTION
Now it's possible to configure gunicorn parameters without duplicating
the original ones in either the CLI command, a new Dockerfile or a
docker-compose.yml.