### PR TITLE
Use Response instead of BaseResponse

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -29,7 +29,7 @@ from flask import (
 from six.moves import range as xrange
 from werkzeug.datastructures import WWWAuthenticate, MultiDict
 from werkzeug.http import http_date
-from werkzeug.wrappers import BaseResponse
+from werkzeug.wrappers import Response as WzResponse
 from werkzeug.http import parse_authorization_header
 from flasgger import Swagger, NO_SANITIZER
 
@@ -77,7 +77,7 @@ def jsonify(*args, **kwargs):
 
 
 # Prevent WSGI from correcting the casing of the Location header
-BaseResponse.autocorrect_location_header = False
+WzResponse.autocorrect_location_header = False
 
 # Find the correct template folder when running from a different location
 tmpl_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")


### PR DESCRIPTION
In the new werkzeug version released on 2022 - 03 - 28, the BaseResponse class has been removed (because it's deprecated) and replaced by Response. Using the Response class in the core.py file will now probably resolve incompatibility issues.
Fixes #673
