### PR TITLE
Pin pipenv version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.kennethreitz.vendor="Kenneth Reitz"
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-RUN apt update -y && apt install python3-pip git -y && pip3 install --no-cache-dir pipenv
+RUN apt update -y && apt install python3-pip git -y && pip3 install --no-cache-dir pipenv==2022.4.8
 
 ADD Pipfile Pipfile.lock /httpbin/
 WORKDIR /httpbin


### PR DESCRIPTION
Pipenv dropped support for Python 3.6 
- https://github.com/pypa/pipenv/issues/5065
- https://github.com/pypa/pipenv/releases/tag/v2022.4.21

**Description of bug:**
Running `docker compose build && docker compose up` would fail with the message `ERROR: for httpbin  Cannot start service httpbin: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "gunicorn": executable file not found in $PATH: unknown` since `pipenv` was failing to set up any libraries.