### PR TITLE
Fix bare except clauses in httpbin/core.py and httpbin/helpers.py

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -178,7 +178,7 @@ if os.environ.get("BUGSNAG_API_KEY") is not None:
             ignore_classes=["werkzeug.exceptions.NotFound"],
         )
         bugsnag.flask.handle_exceptions(app)
-    except:
+    except Exception:
         app.logger.warning("Unable to initialize Bugsnag exception handling.")
 
 # -----------
@@ -1307,7 +1307,7 @@ def decode_base64(value):
     encoded = value.encode("utf-8")  # base64 expects binary string as input
     try:
         return base64.urlsafe_b64decode(encoded).decode("utf-8")
-    except:
+    except Exception:
         return "Incorrect Base64 data try: SFRUUEJJTiBpcyBhd2Vzb21l"
 
 

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -402,12 +402,12 @@ def __parse_request_range(range_header_text):
 
     try:
         right = int(components[1])
-    except:
+    except (ValueError, IndexError):
         pass
 
     try:
         left = int(components[0])
-    except:
+    except (ValueError, IndexError):
         pass
 
     return left, right


### PR DESCRIPTION
Replace 4 bare `except:` clauses with specific exception types across two files.

**httpbin/core.py** (2 fixes → `except Exception:`):
- Bugsnag initialization fallback
- Base64 URL-safe decode error handler

**httpbin/helpers.py** (2 fixes → `except (ValueError, IndexError):`):
- Two `int()` parse attempts in the byte-range header parser

Bare `except:` catches `BaseException` including `SystemExit` and `KeyboardInterrupt`, which is almost never intended. Specific exception types make the error handling explicit and safe.